### PR TITLE
feat: 메인페이지 카카오톡 공유 버튼 항상 표시

### DIFF
--- a/BimilLog_front/components/organisms/home/HomeHero.tsx
+++ b/BimilLog_front/components/organisms/home/HomeHero.tsx
@@ -76,15 +76,6 @@ export const HomeHero: React.FC<HomeHeroProps> = ({
                   롤링페이퍼 둘러보기
                 </Button>
               </div>
-
-              {/* PC: 카카오톡 공유 버튼을 한 칸 아래에 */}
-              <div className="hidden sm:block">
-                <KakaoShareButton
-                  type="service"
-                  size="lg"
-                  className="px-8 py-3 text-lg font-semibold"
-                />
-              </div>
             </>
           )}
 
@@ -99,16 +90,23 @@ export const HomeHero: React.FC<HomeHeroProps> = ({
             </Button>
           </div>
 
-          {/* 모바일: 카카오톡 공유 버튼을 맨 아래에 */}
-          {isAuthenticated && (
-            <div className="sm:hidden">
-              <KakaoShareButton
-                type="service"
-                size="lg"
-                className="px-8 py-3 text-lg font-semibold"
-              />
-            </div>
-          )}
+          {/* PC: 카카오톡 공유 버튼 - 로그인 여부 관계없이 항상 표시 */}
+          <div className="hidden sm:block">
+            <KakaoShareButton
+              type="service"
+              size="lg"
+              className="px-8 py-3 text-lg font-semibold"
+            />
+          </div>
+
+          {/* 모바일: 카카오톡 공유 버튼 - 로그인 여부 관계없이 항상 표시 */}
+          <div className="sm:hidden">
+            <KakaoShareButton
+              type="service"
+              size="lg"
+              className="px-8 py-3 text-lg font-semibold"
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
로그인 여부와 관계없이 모든 사용자가 카카오톡 공유 버튼을 볼 수 있도록 변경
- PC 버전과 모바일 버전 공유 버튼을 isAuthenticated 조건 밖으로 이동
- 비로그인 사용자도 서비스를 쉽게 공유할 수 있도록 UX 개선