### PR TITLE
revert: layout.tsx와 next.config.ts의 charset 설정 원래대로 복구

### DIFF
--- a/BimilLog_front/app/layout.tsx
+++ b/BimilLog_front/app/layout.tsx
@@ -120,7 +120,6 @@ export default function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <head>
-        <meta charSet="utf-8" />
         <ThemeModeScript />
         {/* Preconnect & DNS Prefetch */}
         <link rel="preconnect" href="https://grow-farm.com" />

--- a/BimilLog_front/next.config.ts
+++ b/BimilLog_front/next.config.ts
@@ -101,13 +101,19 @@ const nextConfig = withPWA(pwaConfig)({
                 ],
             },
             {
-                // 모든 HTML 페이지에 Content-Type 헤더 명시적 설정
-                source: '/:path*',
+                // admin 페이지에 Content-Type 헤더 명시적 설정
+                source: '/admin/:path*',
                 headers: [
                     {
                         key: 'Content-Type',
                         value: 'text/html; charset=utf-8',
                     },
+                ],
+            },
+            {
+                // 모든 페이지에 보안 헤더 적용
+                source: '/:path*',
+                headers: [
                     {
                         key: 'Content-Security-Policy',
                         value: [


### PR DESCRIPTION
layout.tsx의 charset 메타 태그와 next.config.ts의
전역 Content-Type 헤더 설정을 제거하여 원래 상태로 복구했습니다.

복구된 내용:
- layout.tsx: charset 메타 태그 제거
- next.config.ts: admin 페이지만 Content-Type 헤더 설정하도록 복구

에디터 컴포넌트의 한글 텍스트 인코딩 수정만 유지됩니다.